### PR TITLE
external/fieldtrip/src typo & isnan(int) `make external` fixes

### DIFF
--- a/external/fieldtrip/src/ft_getopt.c
+++ b/external/fieldtrip/src/ft_getopt.c
@@ -46,7 +46,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
 				mexErrMsgTxt("the key should be specified as a string");
                 
         if (nrhs == 4 && !(mxIsLogical(prhs[3]) || mxIsNumeric(prhs[3]))) {
-            mxErrMsgTxt("if specified, input argument emptymeaningful should be a logical or numeric value");
+            mexErrMsgTxt("if specified, input argument emptymeaningful should be a logical or numeric value");
         }
         
         if (nrhs < 4) {

--- a/external/fieldtrip/src/nanmean.c
+++ b/external/fieldtrip/src/nanmean.c
@@ -8,8 +8,10 @@
 double fname(nanstat, TYPE)(int n, TYPE *x0, mwSize stride) \
 {\
   int i; INTERMEDIATE_TYPE result = 0, c=0;\
+  float j;\
   for (i = 0; i < n; ++i) {\
-    if (!isnan(x0[i * stride])){\
+    	j = (float) x0[i * stride];\
+	if (!isnan(j)){\
       result += x0[i * stride];\
       c += 1;\
     }\

--- a/external/fieldtrip/src/nannumel.c
+++ b/external/fieldtrip/src/nannumel.c
@@ -8,8 +8,10 @@
 double fname(nanstat, TYPE)(int n, TYPE *x0, mwSize stride) \
 {\
   int i; int count = 0;\
+  float j;\
   for (i = 0; i < n; ++i) {\
-    if (!isnan(x0[i * stride]))\
+	j = (float) x0[i * stride];\
+    if (!isnan(j))\
       count += 1;\
   }\
   return count;\

--- a/external/fieldtrip/src/nansum.c
+++ b/external/fieldtrip/src/nansum.c
@@ -8,8 +8,10 @@
 double fname(nanstat, TYPE)(int n, TYPE *x0, mwSize stride) \
 {\
   int i; INTERMEDIATE_TYPE result = 0;\
+  float j;\
   for (i = 0; i < n; ++i) {\
-    if (!isnan(x0[i * stride]))\
+	j = (float) x0[i * stride];\
+    if (!isnan(j))\
       result += x0[i * stride];\
   }\
   return result;\

--- a/external/fieldtrip/src/nanvar_base.c
+++ b/external/fieldtrip/src/nanvar_base.c
@@ -9,8 +9,10 @@ double fname(nanstat, TYPE)(int n, TYPE *x0, mwSize stride) \
 {\
   /* Compute mean first: */\
   int i; INTERMEDIATE_TYPE result = 0, c=0, mean=0;\
+  float j;\
   for (i = 0; i < n; ++i) {\
-    if (!isnan(x0[i * stride])){\
+	j = (float) x0[i * stride];\ 
+   if (!isnan(j)){\
       result += x0[i * stride];\
       c += 1;\
     }\
@@ -20,7 +22,8 @@ double fname(nanstat, TYPE)(int n, TYPE *x0, mwSize stride) \
   /* Compute variance: */\
   result = 0; \
   for (i = 0; i < n; ++i) {\
-    if (!isnan(x0[i * stride])){\
+	j = (float) x0[i * stride];\ 
+    if (!isnan(j)){\
       result += pow(x0[i * stride] - mean, 2);\
     }\
   }\


### PR DESCRIPTION
Changes in spm8/external/fieldtrip/src:

`ft_getopt.c` line 49 "mx..." instead of "mex..." typo causing error during `make external && make external-install`

`nan*.c`: added dummy `float j` variable to pass to `isnan()`. Passing the various int types (non-float) during these function definitions caused make to fail.

With these changes all `make external && make external-install` succeeded.

Compiled on Arch Linux 4.12.13-1-x86_64, with `PATH` setting GCC version to 4.9.4. 
Changing `Makefile.var` for `MEX = /usr/local/MATLAB/$release/bin/mex` was also necessary.

I'll fully disclose that I'm not very comfortable in C and these are suggestions that allow the software to install on contemporary systems for anyone needing SPM8 specifically.

